### PR TITLE
Enhance WiFi Direct functionality and improve chat navigation

### DIFF
--- a/lib/controllers/home_controller.dart
+++ b/lib/controllers/home_controller.dart
@@ -125,7 +125,7 @@ class HomeController extends ChangeNotifier {
 
           if (_discoveredDevices.isEmpty) {
             debugPrint("📭 No devices found during scan");
-            debugPrint("🔍 Available WiFi Direct peers: ${p2pService.wifiDirectService.discoveredPeers.length}");
+            debugPrint("🔍 Available WiFi Direct peers: ${p2pService.wifiDirectService?.discoveredPeers.length ?? 0}");
             debugPrint("🔍 ResQLink devices: ${p2pService.discoveredResQLinkDevices.length}");
             debugPrint("🔍 Available hotspots: ${p2pService.getAvailableHotspots().length}");
           } else {

--- a/lib/pages/message_page.dart
+++ b/lib/pages/message_page.dart
@@ -135,6 +135,14 @@ class MessagePage extends StatefulWidget {
 
   @override
   State<MessagePage> createState() => _MessagePageState();
+
+  // Static method to access the state externally
+  static void selectDeviceFor(GlobalKey key, String deviceId, String deviceName) {
+    final state = key.currentState;
+    if (state != null && state is _MessagePageState) {
+      state.selectDevice(deviceId, deviceName);
+    }
+  }
 }
 
 class _MessagePageState extends State<MessagePage> with WidgetsBindingObserver {
@@ -879,6 +887,11 @@ class _MessagePageState extends State<MessagePage> with WidgetsBindingObserver {
       _isChatView = true;
     });
     _loadMessagesForDevice(endpointId);
+  }
+
+  // Public method for external navigation
+  void selectDevice(String deviceId, String deviceName) {
+    _openConversation(deviceId, deviceName);
   }
 
   void _scrollToBottom() {


### PR DESCRIPTION
- Updated HomeController to safely access discovered peers in WiFi Direct.
- Modified HomePage to include a GlobalKey for MessagePage to facilitate external control.
- Implemented chat navigation from ConnectionDiscoveryCard, allowing users to tap on devices to initiate chats.
- Added a static method in MessagePage to select devices externally.
- Enhanced P2PMainService to handle nullable WiFiDirectService and ensure safe access to its methods.
- Improved WiFiDirectService to prevent concurrent refreshes of the peer list and ensure accurate connection state updates.
- Updated ConnectionDiscoveryCard to handle device chat initiation and improved UI feedback for chat actions.